### PR TITLE
Use Json serializer to process custom strategies

### DIFF
--- a/src/Helper/Config.php
+++ b/src/Helper/Config.php
@@ -18,13 +18,18 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     /** @var \Magento\Cms\Helper\Page $cmsPageHelper */
     protected $cmsPageHelper;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json $serializer */
+    protected $serializer;
+
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Cms\Helper\Page $cmsPageHelper
+        \Magento\Cms\Helper\Page $cmsPageHelper,
+        \Magento\Framework\Serialize\Serializer\Json $serializer
     ) {
         parent::__construct($context);
 
         $this->cmsPageHelper = $cmsPageHelper;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -65,7 +70,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
         $custom_strategies = $this->scopeConfig->getValue(static::XML_PATH_CUSTOM_STRATEGIES, ScopeInterface::SCOPE_STORE, $store);
 
         if (is_string($custom_strategies) && !empty($custom_strategies)) {
-            $custom_strategies = unserialize($custom_strategies);
+            $custom_strategies = $this->serializer->unserialize($custom_strategies);
         }
 
         if (!is_array($custom_strategies)) {

--- a/src/Setup/InstallData.php
+++ b/src/Setup/InstallData.php
@@ -21,14 +21,19 @@ class InstallData implements InstallDataInterface
     /** @var \Magento\Framework\App\Config\Storage\WriterInterface $configWriter */
     protected $configWriter;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json $serializer */
+    protected $serializer;
+
     public function __construct(
         \Magento\Cms\Model\PageFactory $pageFactory,
         \Magento\Cms\Model\PageRepository $pageRepository,
-        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
+        \Magento\Framework\Serialize\Serializer\Json $serializer
     ) {
         $this->pageFactory = $pageFactory;
         $this->pageRepository = $pageRepository;
         $this->configWriter = $configWriter;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -74,7 +79,7 @@ class InstallData implements InstallDataInterface
 
         $this->configWriter->save(
             "web/serviceworker/custom_strategies",
-            serialize($strategies)
+            $this->serializer->serialize($strategies)
         );
 
         $setup->endSetup();

--- a/src/Setup/UpgradeData.php
+++ b/src/Setup/UpgradeData.php
@@ -15,12 +15,17 @@ class UpgradeData implements UpgradeDataInterface
     /** @var \Magento\Framework\App\Config\Storage\WriterInterface $configWriter */
     protected $configWriter;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json $serializer */
+    protected $serializer;
+
     public function __construct(
         \Magento\Framework\App\Config\ValueInterface $configReader,
-        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
+        \Magento\Framework\Serialize\Serializer\Json $serializer
     ) {
         $this->configReader = $configReader;
         $this->configWriter = $configWriter;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -63,7 +68,7 @@ class UpgradeData implements UpgradeDataInterface
 
                     $this->configWriter->save(
                         "web/serviceworker/custom_strategies",
-                        serialize($value),
+                        $this->serializer->serialize($value),
                         $config->getScope(),
                         $config->getScopeId()
                     );
@@ -87,7 +92,7 @@ class UpgradeData implements UpgradeDataInterface
 
                     $this->configWriter->save(
                         "web/serviceworker/custom_strategies",
-                        serialize($strategies)
+                        $this->serializer->serialize($strategies)
                     );
                 }
             }


### PR DESCRIPTION
This matches serialization done by the
\Magento\Config\Model\Config\Backend\Serialized\ArraySerialized class
when saving the custom strategies in the admin area in Magento 2.2.

Fixes #9.