### PR TITLE
Support latest Magento versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     }
   },
   "require": {
-    "magento/framework": "^101.0.0",
-    "magento/module-backend": "^100.1.1",
-    "magento/module-config": "^101.0.0",
-    "magento/module-cms": "^102.0.0"
+    "magento/framework": ">=101.0.0",
+    "magento/module-backend": ">=100.1.1",
+    "magento/module-config": ">=101.0.0",
+    "magento/module-cms": ">=102.0.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
```
    - meanbee/magento2-serviceworker 2.2.0 requires magento/framework ^101.0.0 -> satisfiable by magento/framework[101.0.10, 101.0.0-rc21, 101.0.0-rc22, 101.0.0-rc23, 101.0.0-rc30, 101.0.0, 101.0.1, 101.0.2, 101.0.3, 101.0.4, 101.0.5, 101.0.6, 101.0.7, 101.0.8, 101.0.9].
```